### PR TITLE
feat: show query param to filter cashu/fedimint

### DIFF
--- a/src/components/mainTable/MainTable.tsx
+++ b/src/components/mainTable/MainTable.tsx
@@ -125,6 +125,17 @@ const MintTable = () => {
     if (router.query.mintPubkey) {
       setMintUrlToShow(router.query.mintPubkey as string);
     }
+
+    if (router.query.show) {
+      const showParam = router.query.show;
+      if (showParam === "cashu") {
+        setShowCashu(true);
+        setShowFedimint(false);
+      } else if (showParam === "fedimint") {
+        setShowCashu(false);
+        setShowFedimint(true);
+      }
+    }
   }, [router.query]);
 
   useEffect(() => {


### PR DESCRIPTION
Adds a "show" query param to filter cashu/fedimints on load.

I'm adding this into fedi as a mod and need to just filter for fedimints when they click on it.