### PR TITLE
feat: fedimint support with observer

### DIFF
--- a/src/components/buttons/ListMintButton.tsx
+++ b/src/components/buttons/ListMintButton.tsx
@@ -13,7 +13,7 @@ const ListMintButton = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [mintUrl, setMintUrl] = useState("");
   const [mintPubkey, setMintPubkey] = useState("");
-  const [inviteCodes, setInviteCodes] = useState<string[]>([]);
+  const [inviteCode, setInviteCode] = useState("");
   const [isProcessing, setIsProcessing] = useState(false);
 
   const mints = useSelector((state: RootState) => state.nip87.mintInfos);
@@ -28,14 +28,14 @@ const ListMintButton = () => {
     setIsModalOpen(false);
     setIsProcessing(false);
     setMintUrl("");
-    setInviteCodes([]);
+    setInviteCode("");
     setMintPubkey("");
   };
 
   const handleListFedimint = async () => {
     const mintInfoEvent = await nip87Info(ndk, Nip87MintTypes.Fedimint, {
       mintPubkey,
-      inviteCodes,
+      inviteCodes: [inviteCode],
     });
 
     console.log("mintInfoEvent", mintInfoEvent.rawEvent());
@@ -66,7 +66,7 @@ const ListMintButton = () => {
 
     setIsProcessing(true);
 
-    if (!mintUrl && mintPubkey && inviteCodes) {
+    if (!mintUrl && mintPubkey && inviteCode) {
       return await handleListFedimint();
     }
 
@@ -126,8 +126,8 @@ const ListMintButton = () => {
         isProcessing={isProcessing}
         mintPubkey={mintPubkey}
         setMintPubkey={setMintPubkey}
-        inviteCodes={inviteCodes}
-        setInviteCodes={setInviteCodes}
+        inviteCode={inviteCode}
+        setInviteCode={setInviteCode}
       />
     </div>
   );

--- a/src/components/mainTable/MainTable.tsx
+++ b/src/components/mainTable/MainTable.tsx
@@ -180,11 +180,24 @@ const MintTable = () => {
       { closeOnEose: false }
     );
 
-    mintSub.on("event", (event: NDKEvent) => {
+    mintSub.on("event", async (event: NDKEvent) => {
       if (event.kind === Nip87Kinds.FediInfo) {
-        const mintName = `Fedimint ${event
-          .getMatchingTags("d")[0][1]
-          .slice(0, 3)}...${event.getMatchingTags("d")[0][1].slice(-3)}`;
+        // Fetch the mint name with fedimint observer
+        const inviteCode = event.getMatchingTags("u")[0]?.[1];
+        const response = await fetch(
+          `https://fmo.sirion.io/config/${inviteCode}/meta`
+        );
+        const data = await response.json();
+        let mintName = "Fedimint: ";
+        if (!data.federation_name) {
+          mintName =
+            mintName +
+            `${event.getMatchingTags("d")[0][1].slice(0, 3)}...${event
+              .getMatchingTags("d")[0][1]
+              .slice(-3)}`;
+        } else {
+          mintName = mintName + data.federation_name;
+        }
         dispatch(addMint({ event: event.rawEvent(), mintName, units: [] }));
       }
       dispatch(

--- a/src/components/mainTable/MintsRowItem.tsx
+++ b/src/components/mainTable/MintsRowItem.tsx
@@ -14,6 +14,7 @@ import FediCodesModal from "../modals/FediCodesModal";
 const MintsRowItem = ({ mint }: { mint: Nip87MintInfo }) => {
   const [copied, setCopied] = useState(false);
   const [showFediCodesModal, setShowFediCodesModal] = useState(false);
+  const [modules, setModules] = useState<string>("");
   const [reviewData, setReviewData] = useState<{
     avgRating: number;
     numReviewsWithRating: number;
@@ -79,6 +80,27 @@ const MintsRowItem = ({ mint }: { mint: Nip87MintInfo }) => {
     );
   };
 
+  useEffect(() => {
+    if (
+      !mint.supportedNuts &&
+      mint.inviteCodes &&
+      mint.inviteCodes.length > 0
+    ) {
+      const inviteCode = mint.inviteCodes[0];
+      const fetchModulesUrl = `https://fmo.sirion.io/config/${inviteCode}/module_kinds`;
+
+      // Fetch modules from the URL
+      fetch(fetchModulesUrl)
+        .then((response) => response.json())
+        .then((data) => {
+          setModules(data.join(", ").toUpperCase());
+        })
+        .catch((error) => {
+          console.error("Error fetching modules:", error);
+        });
+    }
+  }, [mint]);
+
   return (
     <>
       <Table.Row className="dark:bg-gray-800">
@@ -113,21 +135,20 @@ const MintsRowItem = ({ mint }: { mint: Nip87MintInfo }) => {
         {/*  Mint Url */}
         <Table.Cell className="hover:cursor-pointer" onClick={handleCopy}>
           <div className="flex">
-            {shortenString(mint.mintUrl || "Invite Codes")}
             {copied ? (
               <BsClipboard2CheckFill className="ml-1 mt-1" size={15} />
             ) : (
               <BsClipboard2 className="ml-1 mt-1" size={15} />
             )}
+            {shortenString(mint.mintUrl || mint.inviteCodes![0])}
           </div>
         </Table.Cell>
-
-        {/* Supported */}
         <Table.Cell>
           <div>
             <p>
-              <strong>Nuts: </strong>
-              {mint.supportedNuts || "N/A"}
+              {mint.supportedNuts
+                ? "NUTS: " + mint.supportedNuts
+                : "MODULES: " + modules}
             </p>
             <p>
               <strong>Units: </strong>

--- a/src/components/modals/FediCodesModal.tsx
+++ b/src/components/modals/FediCodesModal.tsx
@@ -16,7 +16,7 @@ const FediCodesModal = ({
   if (inviteCodes === undefined || inviteCodes.length === 0) return null;
   return (
     <Modal show={show} onClose={() => setShow(false)}>
-      <Modal.Header>Invite Codes</Modal.Header>
+      <Modal.Header>Invite Code</Modal.Header>
       <Modal.Body>
         <List>
           {inviteCodes.map((code, i) => (

--- a/src/redux/slices/nip87Slice.ts
+++ b/src/redux/slices/nip87Slice.ts
@@ -67,12 +67,14 @@ export const addMintInfosAsync = createAsyncThunk(
     let units: string[] = [];
     if (fetchedMint) {
       mintName = fetchedMint.name;
-    } else {
+    } else if (!mintUrls[0].startsWith("fed")) {
       const mintData = await getMintInfoWithCache(mintUrls[0]);
       const { name } = mintData;
       units = mintData.units;
       dispatch(addMintData(mintData));
       mintName = name;
+    } else {
+      mintName = "Fedimint";
     }
 
     dispatch(addMint({ event, relay, mintName, units }));


### PR DESCRIPTION
Uses Eric's fedimint observer to get fedimint info when listing or viewing mints:

- Replaces federationId with Federation Name for better readability
- Overloads "Supported" to list fedimint modules similar to NUTS for cashu
- User can inspect federation meta of the mint to confirm it's correct
- Disables Listing button until pubkey is set for mint

<img width="1436" alt="image" src="https://github.com/MakePrisms/bitcoinmints/assets/74332828/b19f2ccb-1526-4fce-be10-972fd95fdbaa">

<img width="500" alt="image" src="https://github.com/MakePrisms/bitcoinmints/assets/74332828/e6a26af6-9b07-406c-865c-f6d5a1bb674a">



