### PR TITLE
fix: fix fedimint review modal

### DIFF
--- a/src/components/buttons/ReviewMintButton.tsx
+++ b/src/components/buttons/ReviewMintButton.tsx
@@ -25,7 +25,7 @@ const ReviewMintButton = ({
   const [mintUrl, setMintUrl] = useState(mint?.mintUrl || "");
   const [mintPubkey, setMintPubkey] = useState(mint?.mintPubkey || "");
   const [inviteCodes, setInviteCodes] = useState<string[]>(
-    mint?.inviteCodes || [],
+    mint?.inviteCodes || []
   );
   const [rating, setRating] = useState(0);
   const [review, setReview] = useState("");
@@ -34,6 +34,11 @@ const ReviewMintButton = ({
   const reviews = useSelector((state: RootState) => state.nip87.reviews);
   const mintData = useSelector((state: RootState) => state.nip87.mints);
   const user = useSelector((state: RootState) => state.user);
+
+  let mintType: Nip87MintTypes =
+    mint?.rawEvent.kind === Nip87Kinds.FediInfo || (mintPubkey && !mintUrl)
+      ? Nip87MintTypes.Fedimint
+      : Nip87MintTypes.Cashu;
 
   const dispatch = useDispatch();
 
@@ -80,16 +85,15 @@ const ReviewMintButton = ({
 
     setIsProcessing(true);
     let mintToReview: Nip87MintInfo | Nip87ReccomendationData;
-    let mintType: Nip87MintTypes = Nip87MintTypes.Cashu;
+
     if (mint) {
       mintToReview = mint;
-      if (mint.rawEvent.kind === Nip87Kinds.FediInfo) {
-        mintType = Nip87MintTypes.Fedimint;
-      }
     } else if (mintPubkey && !mintUrl) {
       // this means the mint is a fedimint mint
       mintType = Nip87MintTypes.Fedimint;
-      const mintName = `Fedimint ${mintPubkey.slice(0, 3)}...${mintPubkey.slice(-3)}`;
+      const mintName = `Fedimint ${mintPubkey.slice(0, 3)}...${mintPubkey.slice(
+        -3
+      )}`;
       mintToReview = {
         inviteCodes: inviteCodes,
         supportedNuts: "undefined",
@@ -98,7 +102,7 @@ const ReviewMintButton = ({
       };
     } else if (mintData.find((mint) => mint.url === mintUrl)) {
       const { supportedNuts, name: mintName } = mintData.find(
-        (mint) => mint.url === mintUrl,
+        (mint) => mint.url === mintUrl
       )!;
       mintToReview = { mintUrl, supportedNuts, mintName };
     } else {
@@ -120,7 +124,7 @@ const ReviewMintButton = ({
       mintToReview,
       mintType,
       rating,
-      review,
+      review
     );
 
     dispatch(
@@ -133,7 +137,7 @@ const ReviewMintButton = ({
             inviteCodes: mintToReview.inviteCodes || [],
           },
         ],
-      }),
+      })
     );
     await reviewEvent.publish();
     console.log("Review event", reviewEvent.rawEvent());
@@ -152,6 +156,7 @@ const ReviewMintButton = ({
       <ListReviewModal
         show={isModalOpen}
         onClose={handleModalClose}
+        mintType={mintType}
         mintPubkey={mint?.mintPubkey ? mint?.mintPubkey : mintPubkey}
         setMintPubkey={mint?.mintPubkey ? () => {} : setMintPubkey}
         mintUrl={mint?.mintUrl ? mint?.mintUrl : mintUrl}

--- a/src/components/modals/ListReviewModal.tsx
+++ b/src/components/modals/ListReviewModal.tsx
@@ -244,6 +244,7 @@ const ReviewModalBody = ({
 interface ListReviewModalProps {
   show: boolean;
   onClose: () => void;
+  mintType: Nip87MintTypes;
   mintUrl: string;
   setMintUrl: (url: string) => void;
   mintPubkey: string;
@@ -262,6 +263,7 @@ interface ListReviewModalProps {
 const ListReviewModal = ({
   show,
   onClose,
+  mintType,
   mintUrl,
   setMintUrl,
   mintPubkey,
@@ -284,60 +286,53 @@ const ListReviewModal = ({
         <h3 className="text-2xl font-medium">{title}</h3>
       </Modal.Header>
       <Modal.Body>
-        <Tabs style="underline" className="mt-1">
-          <Tabs.Item title="Cashu">
-            <div className="space-y-6">
-              {type === "review" ? (
-                <ReviewModalBody
-                  mintUrl={mintUrl}
-                  setMintUrl={setMintUrl}
-                  rating={rating}
-                  setRating={setRating}
-                  review={review}
-                  setReview={setReview}
-                  mintType={Nip87MintTypes.Cashu}
-                />
-              ) : (
-                <CashuListingModalBody
-                  mintUrl={mintUrl}
-                  setMintUrl={setMintUrl}
-                />
-              )}
-            </div>
-          </Tabs.Item>
-          <Tabs.Item
-            title="Fedimint"
-            active={inviteCode !== undefined && inviteCode.length > 0}
-          >
-            <div className="space-y-6">
-              {type === "review" ? (
-                <ReviewModalBody
-                  rating={rating}
-                  setRating={setRating}
-                  review={review}
-                  setReview={setReview}
-                  mintType={Nip87MintTypes.Fedimint}
-                  mintPubkey={mintPubkey}
-                  setMintPubkey={setMintPubkey}
-                  inviteCode={inviteCode}
-                  setInviteCode={setInviteCode}
-                />
-              ) : (
-                <FedimintListingModalBody
-                  mintPubkey={mintPubkey}
-                  setMintPubkey={setMintPubkey}
-                  inviteCode={inviteCode}
-                  setInviteCode={setInviteCode}
-                />
-              )}
-            </div>
-          </Tabs.Item>
-        </Tabs>
-        <div className="w-full">
+        <div className="space-y-6">
+          {mintType === Nip87MintTypes.Cashu ? (
+            type === "review" ? (
+              <ReviewModalBody
+                mintUrl={mintUrl}
+                setMintUrl={setMintUrl}
+                rating={rating}
+                setRating={setRating}
+                review={review}
+                setReview={setReview}
+                mintType={mintType}
+              />
+            ) : (
+              <CashuListingModalBody
+                mintUrl={mintUrl}
+                setMintUrl={setMintUrl}
+              />
+            )
+          ) : // Fedimint
+          type === "review" ? (
+            <ReviewModalBody
+              rating={rating}
+              setRating={setRating}
+              review={review}
+              setReview={setReview}
+              mintType={mintType}
+              mintPubkey={mintPubkey}
+              setMintPubkey={setMintPubkey}
+              inviteCode={inviteCode}
+              setInviteCode={setInviteCode}
+            />
+          ) : (
+            <FedimintListingModalBody
+              mintPubkey={mintPubkey}
+              setMintPubkey={setMintPubkey}
+              inviteCode={inviteCode}
+              setInviteCode={setInviteCode}
+            />
+          )}
+        </div>
+        <div className="w-full mt-6">
           <Button
             isProcessing={isProcessing}
             onClick={handleSubmit}
-            disabled={!inviteCode && !mintUrl}
+            disabled={
+              mintType === Nip87MintTypes.Cashu ? !mintUrl : !mintPubkey
+            }
           >
             {submitText}
           </Button>


### PR DESCRIPTION
fixes https://github.com/MakePrisms/bitcoinmints/issues/20 , checks mintType to disable button if key info (mintUrl for cashu mint, federationId as mintPubkey for fedimint) not filled.

Also finds the mint type from the mint info when you click the "review mint" button and immediately sets it to cashu/fedimint properly instead of using the tabs for the reviews. When you click "review" on a cashu mint or fedimint you don't need the tab to the other one.