### PR TITLE
Update Relay list.

### DIFF
--- a/src/hooks/useNdk.tsx
+++ b/src/hooks/useNdk.tsx
@@ -39,7 +39,7 @@ const NDKContext = createContext<NDKContextProps>({
 });
 
 const defaultRelays = [
-  "wss://nostr.mutinywallet.com/",
+  "wss://relay.cashumints.space",
   "wss://relay.damus.io",
   "wss://relay.snort.social",
   "wss://relay.primal.net",


### PR DESCRIPTION
Replaced the relay "wss://nostr.mutinywallet.com" with "wss://relay.cashumints.space" in the default relay list.

Reason:
The Mutiny relay appears to be no longer available or responding reliably. The CashuMints relay is actively maintained and more relevant.