### PR TITLE
fix(core/reviews): default k=38172 + derive a in test helpers

### DIFF
--- a/packages/core/src/reviews/aggregate.test.ts
+++ b/packages/core/src/reviews/aggregate.test.ts
@@ -29,12 +29,21 @@ const D_A = "5fe928ae0970844f3c5253d2e85a88788486edcbd96c070334a4a2d0d0154a77";
 const D_B = "0".repeat(63) + "1";
 
 function makeReview(over: Partial<ReviewRow> & { d?: string } = {}): ReviewRow {
+  const pubkey = over.pubkey ?? `pk${Math.random().toString(36).slice(2, 10)}${"0".repeat(50)}`;
+  const d = over.d ?? D_A;
+  const kind = 38000 as const;
+  // `k` defaults to Cashu (38172) — tests in this file don't differentiate
+  // Cashu vs Fedimint; parse-level `k` handling is covered in parse.test.ts.
+  // `a` is derived from kind/pubkey/d per NIP-87's `<kind>:<pubkey>:<d>`.
+  const k = over.k ?? 38172;
   return {
-    pubkey: `pk${Math.random().toString(36).slice(2, 10)}${"0".repeat(50)}`,
-    kind: 38000,
-    d: over.d ?? D_A,
+    pubkey,
+    kind,
+    d,
     eventId: `${"0".repeat(58)}${Math.random().toString(36).slice(2, 8)}`,
     createdAt: 1_700_000_000,
+    k,
+    a: `${kind}:${pubkey}:${d}`,
     content: "",
     rawTags: [],
     rating: 5,

--- a/packages/core/src/reviews/rank.test.ts
+++ b/packages/core/src/reviews/rank.test.ts
@@ -34,10 +34,16 @@ function dForIndex(n: number): string {
 }
 
 function makeReview(over: Partial<ReviewRow> & { pubkey: string; d: string }): ReviewRow {
+  const kind = 38000 as const;
+  // `k` defaults to Cashu (38172); rank.test only exercises sort order,
+  // which is `k`-agnostic. `a` is derived per NIP-87 `<kind>:<pubkey>:<d>`.
+  const k = over.k ?? 38172;
   return {
-    kind: 38000,
+    kind,
     eventId: `${"0".repeat(58)}${over.pubkey.slice(-6)}`,
     createdAt: 1_700_000_000,
+    k,
+    a: `${kind}:${over.pubkey}:${over.d}`,
     content: "",
     rawTags: [],
     rating: 5,

--- a/packages/core/src/reviews/upsert.test.ts
+++ b/packages/core/src/reviews/upsert.test.ts
@@ -42,12 +42,20 @@ const EID_LOW = `${"0".repeat(60)}aaaa`;
 const EID_HIGH = `${"0".repeat(60)}ffff`;
 
 function makeReview(over: Partial<ReviewRow> = {}): ReviewRow {
+  const pubkey = over.pubkey ?? `pk${"0".repeat(60)}1`;
+  const d = over.d ?? D_VALID;
+  const kind = 38000 as const;
+  // `k` defaults to Cashu (38172); one test below overrides to 38173 for the
+  // Fedimint path. `a` is derived per NIP-87 `<kind>:<pubkey>:<d>`.
+  const k = over.k ?? 38172;
   return {
-    pubkey: `pk${"0".repeat(60)}1`,
-    kind: 38000,
-    d: D_VALID,
+    pubkey,
+    kind,
+    d,
     eventId: EID_LOW,
     createdAt: 1_700_000_000,
+    k,
+    a: `${kind}:${pubkey}:${d}`,
     content: "",
     rawTags: [],
     rating: 5,


### PR DESCRIPTION
## Summary

CI has been red on the last three PRs (#33, #34, #35) — all merged or opened by keeper:bitcoinmints with untested CI. Root cause: PR #33's P0.3 change made `ReviewRow.k` (and `a`) non-optional, but three test files use a local `makeReview` helper whose `Partial<ReviewRow>` input still treats both as optional. The spread into `ReviewRow` trips `TS2322` on `k?: 38172 | 38173 | undefined` not being assignable to `k: 38172 | 38173`. Our flake-pinned local TS was lenient; ubuntu-bunx CI TS is strict.

This PR fixes the typecheck so CI goes green again.

## Changes

- `packages/core/src/reviews/aggregate.test.ts:31-54` — helper defaults `k: 38172`, derives `a` from `kind:pubkey:d`
- `packages/core/src/reviews/rank.test.ts:36-51` — same pattern; one test already passed `pubkey`/`d` via the constrained input type
- `packages/core/src/reviews/upsert.test.ts:44-63` — same pattern; preserves the existing Fedimint override test (`k: 38173` still flows via `...over`)

Three files, +30/-7 lines. Pure test-helper tightening, no production code touched.

## Option chosen: B (defaults inside helper)

Brief preferred Option A (required `k` at every call site) when "call sites are single-digit." There are ~30+ `makeReview` call sites across the three files, so Option A would be heavy mechanical noise with little value — these tests don't exercise `k`-differentiation logic (that's covered in `parse.test.ts`). The parse-layer P0.3 enforcement already validates `k` is present on real events; tests can safely default it.

`a` is derived (not defaulted to a magic string) per NIP-87 `<kind>:<pubkey>:<d>` so the row is spec-conformant.

## Verification

- `bun run typecheck` → 0 errors (was 3)
- `bun run test` → 247 passing (unchanged)
- `bunx biome check packages/` → 16 warnings, 1 info, 0 errors (unchanged baseline)

CI failure proof: https://github.com/MakePrisms/bitcoinmints/pull/35 build history shows the same `TS2322` across runs.

## Not in this PR

- Auditing why two red-CI PRs got merged — coordination failure on the keeper side, not a code issue.
- Refactoring the three local helpers into a shared one — kept mechanical, different files have different signature needs.
- Biome warnings / NIP-09 backlog — out of scope.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>